### PR TITLE
Move react to peer deps and dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
     "url": "https://github.com/souporserious/react-motion-ui-pack/issues"
   },
   "homepage": "https://github.com/souporserious/react-motion-ui-pack",
+  "peerDependencies": {
+    "react": "^0.13.3"
+  },
   "dependencies": {
-    "react": "^0.13.3",
     "react-motion": "^0.3.0"
   },
   "devDependencies": {
@@ -50,6 +52,7 @@
     "lodash": "^3.10.0",
     "node-libs-browser": "^0.5.2",
     "node-sass": "^3.2.0",
+    "react": "^0.13.3",
     "react-measure": "^0.1.3",
     "sass-loader": "^1.0.2",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
`^0.13.3` should be changed to `>=0.13.3` when this supports React 0.14. #17
