### PR TITLE
Added typeof for better server side compatibilty

### DIFF
--- a/lib/get-vendor-prefix.js
+++ b/lib/get-vendor-prefix.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, '__esModule', {
 exports['default'] = getVendorPrefix;
 
 function getVendorPrefix(prop) {
-  if (!document) return prop;
+  if (typeof document == 'undefined') return prop;
 
   var styles = document.createElement('p').style;
   var vendors = ['ms', 'O', 'Moz', 'Webkit'];


### PR DESCRIPTION
Solves missing document variable in server side

```
[0] ROUTER ERROR:   ReferenceError: document is not defined
[0]
[0]   - get-vendor-prefix.js:9 getVendorPrefix
[0]     [mysite]/[react-motion-ui-pack]/lib/get-vendor-prefix.js:9:8
```

Also we need the issue https://github.com/souporserious/react-measure/pull/8 to be merged in order to make react-motion-ui-pack fully compatible with server side rendering.

@souporserious, I think this issue https://github.com/souporserious/react-motion-ui-pack/issues/14 didn't solve it, at least not for me.

By the way, awesome module :+1: 
