### PR TITLE
Add failing test case

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -245,6 +245,7 @@ class App extends Component {
     return(
       <div>
         <Alert type="warning" text="Please figure out what is wrong." />
+        <Alert type="warning" />
         <ToDos/>
         <Menu/>
         <Modal/>


### PR DESCRIPTION
When the `<Alert/>` component example has no text (and therefore the div is not shown), the following error is thrown: "Failed propType: Required prop `styles` was not specified in `TransitionMotion`. Check the render method of `Transition`."
