### PR TITLE
use cross-env & rimraf to support all platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Addon component wrappers for common UI transitions.",
   "main": "lib/react-motion-ui-pack.js",
   "scripts": {
-    "build": "npm run build:lib && NODE_ENV=production webpack --config webpack.prod.config.js",
+    "build": "npm run build:lib && cross-env NODE_ENV=production webpack --config webpack.prod.config.js",
     "build:lib": "babel src --out-dir lib --stage 0",
     "dev": "webpack-dev-server --devtool eval --hot --progress --colors",
-    "prebuild": "rm -rf dist && mkdir dist",
+    "prebuild": "rimraf dist && mkdir dist",
     "prepublish": "npm run build",
-    "postbuild": "NODE_ENV=production TARGET=minify webpack --config webpack.prod.config.js",
+    "postbuild": "cross-env NODE_ENV=production TARGET=minify webpack --config webpack.prod.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -45,6 +45,7 @@
     "babel-core": "^5.6.15",
     "babel-loader": "^5.2.2",
     "babel-plugin-object-assign": "^1.2.0",
+    "cross-env": "^2.0.1",
     "css-loader": "^0.15.1",
     "http-server": "^0.8.0",
     "lodash": "^3.10.0",
@@ -52,6 +53,7 @@
     "node-sass": "^3.2.0",
     "react": "15.2.1",
     "react-dom": "15.2.1",
+    "rimraf": "^2.5.4",
     "sass-loader": "^1.0.2",
     "style-loader": "^0.12.3",
     "webpack": "^1.9.12",


### PR DESCRIPTION
If you use cross-env and rimraf here instead of NODE_ENV directly & rm -rf, this will work on all platforms (ex: Windows). 
