### PR TITLE
Allow to manually calculate style for element

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Callback right before an element enters, passes in your current animating values
 
 Same as `onEnter`, but fires multiple times as an element is leaving.
 
+
+### `interpolateStyle`: PropTypes.func 
+Function used to interpolate current config style to React element style definition. Called on every style calculation. Default to `config-to-style`
+```jsx
+interpolateStyle={ currentStyleValues => { 
+  const reactElementStyles = {} /* transform current styles manually */ 
+  return reactElementStyles
+  } 
+}
+```
 ## FAQ
 
 #### How `appear`, `enter`, & `leave` work

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -6,6 +6,8 @@ import Transition from '../src/react-motion-ui-pack'
 
 import './main.scss';
 
+const TRANSFORM = require('get-prefix')('transform')
+
 class Modal extends Component {
   state = {
     modalOpen: false
@@ -83,13 +85,53 @@ class Alert extends Component {
   }
 }
 
+class AlertWithCustomStyles extends Component {
+  static defaultPops = {
+    type: ''
+  }
+  
+  _interpolateStyle = style => ({
+      [TRANSFORM]: `translate(${style.translateX}%, ${style.translateY}%)`,
+      opacity: style.opacity
+  });
+  
+  render() {
+    const { type, text } = this.props
+    return (
+      <Transition
+        component={false}
+        measure={false}
+        interpolateStyle={this._interpolateStyle}
+        enter={{
+          opacity: 1,
+          translateX: 0,
+          translateY: 0
+        }}
+        leave={{
+          opacity: 0,
+          translateX: 100,
+          translateY: 100
+        }}
+      >
+        {
+          text !== '' &&
+          <div key="alert" className={"alert" + (type && ` alert--${type}`)}>
+            {text}
+          </div>
+        }
+      </Transition>
+    )
+  }
+}
+
 class App extends Component {
   state = {
-    alert: ''
+    alert: '',
+    warn: ''
   }
 
   render() {
-    const { alert } = this.state
+    const { alert, warn } = this.state
     return (
       <div>
         <button
@@ -97,7 +139,13 @@ class App extends Component {
         >
           Toggle Alert
         </button>
+        <button
+          onClick={() => this.setState({ warn: warn === '' ? 'Warning Warning Warning.' : '' })}
+        >
+          Toggle Warning
+        </button>
         <Alert type="warning" text={alert}/>
+        <AlertWithCustomStyles type="info" text={warn} />
         <Modal/>
       </div>
     )

--- a/example/main.scss
+++ b/example/main.scss
@@ -197,6 +197,12 @@ body {
   color: #6F6530;
 }
 
+.alert--info {
+  border-color: #EAE0AE;
+  background-color: #FFE97B;
+  color: #6F6530;
+}
+
 
 ////////////////////////////////
 // Layout

--- a/src/Transition.jsx
+++ b/src/Transition.jsx
@@ -17,7 +17,8 @@ const checkedProps = {
   enter: PropTypes.object,
   leave: PropTypes.object,
   onEnter: PropTypes.func,
-  onLeave: PropTypes.func
+  onLeave: PropTypes.func,
+  interpolateStyle: PropTypes.func
 }
 
 class Transition extends Component {
@@ -29,7 +30,8 @@ class Transition extends Component {
     enter: { opacity: 1 },
     leave: { opacity: 0 },
     onEnter: () => null,
-    onLeave: () => null
+    onLeave: () => null,
+    interpolateStyle: configToStyle
   }
 
   componentWillMount() {
@@ -101,12 +103,13 @@ class Transition extends Component {
   }
 
   _childrenToRender(currValues) {
+    const {interpolateStyle} = this.props;
     return currValues.map(({ key, data, style }) => {
       const child = data
       const childStyle = child.props.style
 
       // convert styles to a friendly structure
-      style = configToStyle(style)
+      style = interpolateStyle(style)
 
       // merge in any styles set by the user
       // Transition styles will take precedence


### PR DESCRIPTION
## What does this do? 
Adds `interpolateStyle` to Transition properties. Default to `config-to-style`. This will allow to manually calculate element styles for cases that `config-to-style` does not support. 
Solves cases like  `transform: translate(${style.translateX}%, ${style.translateY}%)`. 

## Example of usage 
```jsx 
const TRANSFORM = require('get-prefix')('transform')

class AlertWithCustomStyles extends Component {
  static defaultPops = {
    type: ''
  }
  
  _interpolateStyle = style => ({
      [TRANSFORM]: `translate(${style.translateX}%, ${style.translateY}%)`,
      opacity: style.opacity
  });
  
  render() {
    const { type, text } = this.props
    return (
      <Transition
        component={false}
        measure={false}
        interpolateStyle={this._interpolateStyle}
        enter={{
          opacity: 1,
          translateX: 0,
          translateY: 0
        }}
        leave={{
          opacity: 0,
          translateX: 100,
          translateY: 100
        }}
      >
        {
          text !== '' &&
          <div key="alert" className={"alert" + (type && ` alert--${type}`)}>
            {text}
          </div>
        }
      </Transition>
    )
  }
}
```

## What is in this PR? 
PR has updated code, sample and readme. 

## Why? 
This lib provides dramatic simplification for react-motion. But for our use case `config-to-style` is setting limitation that can be easily remove. Would appreciate new version of lib to include this soon.
