### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "get-prefix": "^1.0.0",
+    "prop-types": "^15.5.10",
     "react-motion": "^0.4.5"
   },
   "devDependencies": {

--- a/src/Transition.jsx
+++ b/src/Transition.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children, createElement, cloneElement } from 'react'
+import React, { Component, Children, createElement, cloneElement } from 'react'
+import PropTypes from 'prop-types'
 import { TransitionMotion } from 'react-motion'
 import isElement from './is-element'
 import fromRMStyles from './from-RM-styles'


### PR DESCRIPTION
Using the internal PropTypes export from react is deprecated and throws errors in the console.